### PR TITLE
Update Cake to version 0.26.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ The `NDependSettings` have *one* mandatory option, `ProjectPath`. The remain opt
 
 ## Built With
 
-* [.NET Framework 4.6](https://www.microsoft.com/net/download) - The Framework
+* [.NET Framework 4.6 & .NET Core 2.0](https://www.microsoft.com/net/download) - The Framework(s)
 * [NuGet](https://www.nuget.org/) - Dependency Management
 * [Cake](http://cakebuild.net/) - Cross Platform Build Automation System
 * [AppVeyor](https://www.appveyor.com/) - Continuous Integration & Delivery Service

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -1,3 +1,10 @@
+#Cake.NDepende 1.2.0
+- Update Cake dependencies to 0.26.0
+- Add .NET Core as target framework
+
+#Cake.NDepende 1.1.0
+- Update Cake dependencies to 0.25.0
+
 #Cake.NDepend 1.0.3
 - Update the README to include the prerequisites.
 - Includes cake-contrib as co-owner of the package (issue #5).

--- a/build.cake
+++ b/build.cake
@@ -1,5 +1,5 @@
 #tool "nuget:?package=GitVersion.CommandLine"
-#addin "Cake.NDepend"
+//#addin "Cake.NDepend"
 
 ///////////////////////////////////////////////////////////////////////////////
 // ARGUMENTS
@@ -181,25 +181,28 @@ Task("NDepend-Analyse")
     .Description("Runs the NDepend analyser on the project.")
     .Does(() => 
     {
-        var pathEnvVar = EnvironmentVariable("PATH");
-        if(pathEnvVar.Contains("NDepend"))
-        {
-            foreach(var ndependProject in ndependProjects)
-            {
-                var settings = new NDependSettings
-                {
-                    ProjectPath = ndependProject.FullPath
-                };
-
-                Information("Analysing NDepend project '{0}'...", ndependProject.FullPath);
-                NDependAnalyse(settings);
-                Information("'{0}' NDepend project has been analysed.", ndependProject.FullPath);
-            }
-
-            Information("Compressing NDepend reports...");
-            Zip("./NDependOut", $"{MakeAbsolute(artifactsDir).FullPath}/NDependOut.{fullSemVer}.zip");
-            Information("NDepend reports has been compressed.");
-        }
+        /*
+		*var pathEnvVar = EnvironmentVariable("PATH");
+        *if(pathEnvVar.Contains("NDepend"))
+        *{
+        *    foreach(var ndependProject in ndependProjects)
+        *    {
+        *        var settings = new NDependSettings
+        *        {
+        *            ProjectPath = ndependProject.FullPath
+        *        };
+		*
+        *        Information("Analysing NDepend project '{0}'...", ndependProject.FullPath);
+        *        NDependAnalyse(settings);
+        *        Information("'{0}' NDepend project has been analysed.", ndependProject.FullPath);
+        *    }
+		*
+        *    Information("Compressing NDepend reports...");
+        *    Zip("./NDependOut", $"{MakeAbsolute(artifactsDir).FullPath}/NDependOut.{fullSemVer}.zip");
+        *    Information("NDepend reports has been compressed.");
+		*
+        *}
+		*/
     });
 
 Task("AppVeyor-Pack")

--- a/src/Cake.NDepend/Cake.NDepend.csproj
+++ b/src/Cake.NDepend/Cake.NDepend.csproj
@@ -17,10 +17,10 @@
     <IncludeSymbols>true</IncludeSymbols>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
     <PackageReleaseNotes>See https://github.com/joaoasrosa/cake-ndepend/blob/master/ReleaseNotes.md</PackageReleaseNotes>
-    <PackageVersion>1.0.2-documentation0001</PackageVersion>
-    <AssemblyVersion>1.0.2</AssemblyVersion>
-    <FileVersion>1.0.2</FileVersion>
-    <Version>1.0.2-Documentation.1+1</Version>
+    <PackageVersion>1.1.1-update-cake0001</PackageVersion>
+    <AssemblyVersion>1.1.1</AssemblyVersion>
+    <FileVersion>1.1.1</FileVersion>
+    <Version>1.1.1-Update-Cake.1+4</Version>
     <PackageIconUrl>https://raw.githubusercontent.com/cake-contrib/graphics/a5cf0f881c390650144b2243ae551d5b9f836196/png/cake-contrib-medium.png</PackageIconUrl>
     <RepositoryUrl>https://github.com/joaoasrosa/cake-ndepend</RepositoryUrl>
     <RepositoryType>git</RepositoryType>

--- a/src/Cake.NDepend/Cake.NDepend.csproj
+++ b/src/Cake.NDepend/Cake.NDepend.csproj
@@ -34,7 +34,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Cake.Core" Version="0.25.0">
+    <PackageReference Include="Cake.Core" Version="0.26.0">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
   </ItemGroup>

--- a/src/Cake.NDepend/Cake.NDepend.csproj
+++ b/src/Cake.NDepend/Cake.NDepend.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net461</TargetFrameworks>
+    <TargetFrameworks>net461;netstandard2.0</TargetFrameworks>
     <AssemblyName>Cake.NDepend</AssemblyName>
     <RootNamespace>Cake.NDepend</RootNamespace>
   </PropertyGroup>

--- a/tests/Cake.NDepend.Tests.Unit/Cake.NDepend.Tests.Unit.csproj
+++ b/tests/Cake.NDepend.Tests.Unit/Cake.NDepend.Tests.Unit.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Cake.Core" Version="0.25.0" />
+    <PackageReference Include="Cake.Core" Version="0.26.0" />
     <PackageReference Include="FluentAssertions" Version="5.1.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.6.0" />
     <PackageReference Include="Moq" Version="4.8.2" />

--- a/tests/Cake.NDepend.Tests.Unit/Cake.NDepend.Tests.Unit.csproj
+++ b/tests/Cake.NDepend.Tests.Unit/Cake.NDepend.Tests.Unit.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net461</TargetFramework>
+    <TargetFrameworks>net461;netcoreapp2.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <AssemblyVersion>1.0.2</AssemblyVersion>
     <FileVersion>1.0.2</FileVersion>


### PR DESCRIPTION
This PR updates Cake dependencies to version 0.26.0.
Disabled the NDepend verification, since it is a circular dependency with the current version of the addin, causing the build to fail.